### PR TITLE
Fix algorithms not appearing in the Algorithms view

### DIFF
--- a/org.geocraft.algorithm/src/org/geocraft/algorithm/StandaloneAlgorithmRegistry.java
+++ b/org.geocraft.algorithm/src/org/geocraft/algorithm/StandaloneAlgorithmRegistry.java
@@ -38,7 +38,8 @@ public class StandaloneAlgorithmRegistry {
     // Get the algorithms registered via the standard extension point.
     IConfigurationElement[] configElements = registry.getConfigurationElementsFor("org.geocraft.algorithm");
     for (IConfigurationElement configElement : configElements) {
-      result.add(new StandaloneAlgorithmDescription(configElement));
+      StandaloneAlgorithmDescription desc = new StandaloneAlgorithmDescription(configElement);
+      result.add(desc);
     }
 
     // Get the algorithms registered via the programmatic provider extension point.
@@ -51,7 +52,6 @@ public class StandaloneAlgorithmRegistry {
           result.add(algorithmDesc);
         }
       } catch (CoreException e) {
-        // TODO Auto-generated catch block
         e.printStackTrace();
       }
     }

--- a/org.geocraft.geomath/src/org/geocraft/internal/geomath/view/AlgorithmsView.java
+++ b/org.geocraft.geomath/src/org/geocraft/internal/geomath/view/AlgorithmsView.java
@@ -81,12 +81,7 @@ public class AlgorithmsView extends ViewPart implements IMessageSubscriber {
     _filterText.setText(FILTER_TEXT);
 
     _viewer = new TreeViewer(parent, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
-    GridData viewerLayoutData = new GridData();
-    viewerLayoutData.grabExcessHorizontalSpace = true;
-    viewerLayoutData.grabExcessVerticalSpace = true;
-    viewerLayoutData.horizontalAlignment = SWT.FILL;
-    viewerLayoutData.verticalAlignment = SWT.FILL;
-    _viewer.getTree().setLayoutData(viewerLayoutData);
+    _viewer.getTree().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
     _filterText.addKeyListener(new KeyAdapter() {
 
       @Override
@@ -104,6 +99,9 @@ public class AlgorithmsView extends ViewPart implements IMessageSubscriber {
     _viewer.setLabelProvider(new ViewLabelProvider());
     _viewer.setSorter(new ViewerSorter());
     _viewer.setInput(getViewSite());
+    // Force refresh and expand top-level to work around JFace 3.5.1 / SWT 3.122.0 rendering gap
+    _viewer.refresh();
+    _viewer.expandToLevel(2);
     getSite().setSelectionProvider(_viewer);
     _viewer.addFilter(new ViewerFilter() {
 

--- a/org.geocraft.geomath/src/org/geocraft/internal/geomath/view/ViewContentProvider.java
+++ b/org.geocraft.geomath/src/org/geocraft/internal/geomath/view/ViewContentProvider.java
@@ -63,7 +63,7 @@ public class ViewContentProvider implements IStructuredContentProvider, ITreeCon
   }
 
   /*
-   * We will set up a dummy model to initialize tree hierarchy. 
+   * We will set up a dummy model to initialize tree hierarchy.
    * In a real code, you will connect to a real model and expose its hierarchy.
    */
   private void initialize() {
@@ -74,7 +74,8 @@ public class ViewContentProvider implements IStructuredContentProvider, ITreeCon
       if (!tool.isVisible()) {
         continue;
       }
-      String[] paths = tool.getFullPath().split("/");
+      String fullPath = tool.getFullPath();
+      String[] paths = fullPath.split("/");
       int level = 1;
       for (String path : paths) {
         TreeObject treeNode = locateNode(paths, path, level);
@@ -83,6 +84,9 @@ public class ViewContentProvider implements IStructuredContentProvider, ITreeCon
             _invisibleRoot.addChild(new TreeParent(path));
           } else {
             TreeParent parentNode = (TreeParent) locateNode(paths, paths[level - 2], level - 1);
+            if (parentNode == null) {
+              break;
+            }
             if (level < paths.length) {
               parentNode.addChild(new TreeParent(path));
             } else {
@@ -116,32 +120,6 @@ public class ViewContentProvider implements IStructuredContentProvider, ITreeCon
       }
       temp++;
     }
-
-    //    TreeObject node = null;
-    //    List<TreeObject> prevLevelObjects = new ArrayList<TreeObject>();
-    //    List<TreeObject> levelObjects = new ArrayList<TreeObject>();
-    //    prevLevelObjects.add(_invisibleRoot);
-    //    // build the existing levels
-    //    for (int i = 0; i < level; i++) {
-    //      for (TreeObject object : prevLevelObjects) {
-    //        if (object instanceof TreeParent) {
-    //          levelObjects.addAll(Arrays.asList(((TreeParent) object).getChildren()));
-    //        }
-    //      }
-    //      if (i < level - 1) {
-    //        prevLevelObjects.clear();
-    //        prevLevelObjects.addAll(levelObjects);
-    //        levelObjects.clear();
-    //      }
-    //    }
-    //
-    //    // locate the node
-    //    for (int i = 0; i < levelObjects.size() && node == null; i++) {
-    //      TreeObject currentNode = levelObjects.get(i);
-    //      if (currentNode.getName().equals(nodeName)) {
-    //        node = currentNode;
-    //      }
-    //    }
     return null;
   }
 

--- a/org.geocraft.geomath/src/org/geocraft/internal/geomath/view/ViewLabelProvider.java
+++ b/org.geocraft.geomath/src/org/geocraft/internal/geomath/view/ViewLabelProvider.java
@@ -5,6 +5,9 @@ package org.geocraft.internal.geomath.view;
 
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.jface.resource.ResourceManager;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.ISharedImages;
@@ -15,18 +18,12 @@ import org.geocraft.ui.common.image.ImageRegistryUtil;
 
 public class ViewLabelProvider extends LabelProvider {
 
+  private final ResourceManager _resourceManager = new LocalResourceManager(JFaceResources.getResources());
+
   @Override
   public String getText(final Object obj) {
     return obj.toString();
   }
-
-  //  public Image getImage(Object obj) {
-  //    String imageKey = ISharedImages.IMG_OBJ_ELEMENT;
-  //    if (obj instanceof TreeParent) {
-  //      imageKey = ISharedImages.IMG_OBJ_FOLDER;
-  //    }
-  //    return PlatformUI.getWorkbench().getSharedImages().getImage(imageKey);
-  //  }
 
   @Override
   public Image getImage(final Object object) {
@@ -38,9 +35,15 @@ public class ViewLabelProvider extends LabelProvider {
     if (toolDesc != null) {
       ImageDescriptor imageDesc = treeObject.getStandaloneAlgorithm().getIcon();
       if (imageDesc != null) {
-        return imageDesc.createImage();
+        return _resourceManager.createImage(imageDesc);
       }
     }
     return ImageRegistryUtil.getSharedImages().getImage(org.geocraft.ui.common.image.ISharedImages.IMG_TOOL_24);
+  }
+
+  @Override
+  public void dispose() {
+    _resourceManager.dispose();
+    super.dispose();
   }
 }

--- a/org.geocraft.product/src/org/geocraft/product/ApplicationWorkbenchWindowAdvisor.java
+++ b/org.geocraft.product/src/org/geocraft/product/ApplicationWorkbenchWindowAdvisor.java
@@ -68,6 +68,15 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 
   @Override
   public void postWindowOpen() {
+    // Workaround: SWT 3.122.0 on macOS doesn't compute initial SashForm sizes
+    // correctly with Eclipse 3.5.1 workbench. Force a relayout by toggling the
+    // shell size, which triggers all sash containers to recompute their children.
+    IWorkbenchWindow window = getWindowConfigurer().getWindow();
+    org.eclipse.swt.widgets.Shell shell = window.getShell();
+    Point size = shell.getSize();
+    shell.setSize(size.x + 1, size.y + 1);
+    shell.setSize(size.x, size.y);
+
     //Note: This method is called each time a workbench window is opened, for example,
     //      when a session is restored. Only want to restore an active session when
     //      initially launch Geocraft.

--- a/org.geocraft.ui.common/src/org/geocraft/internal/ui/common/SharedImages.java
+++ b/org.geocraft.ui.common/src/org/geocraft/internal/ui/common/SharedImages.java
@@ -92,11 +92,11 @@ public class SharedImages implements ISharedImages {
   private final Map<String, String> _keyToPath = new HashMap<String, String>();
 
   public Image getImage(final String key) {
-    ImageDescriptor desc = getImageDescriptor(key);
-    if (desc == null) {
-      return null;
-    }
-    return desc.createImage();
+    // Ensure the descriptor is registered in the ImageRegistry.
+    getImageDescriptor(key);
+    // Return the managed Image from the ImageRegistry (handles lifecycle).
+    ImageRegistry imageRegistry = ServiceComponent.getImageRegistry();
+    return imageRegistry.get(key);
   }
 
   public ImageDescriptor getImageDescriptor(final String key) {


### PR DESCRIPTION
## Summary
- **Fix SWT resource leaks**: `SharedImages.getImage()` and `ViewLabelProvider.getImage()` created unmanaged `Image` objects via `ImageDescriptor.createImage()`, causing SWT 3.122.0's strict resource tracking to throw `java.lang.Error` on every tree item render. Fixed by using `ImageRegistry.get()` and `LocalResourceManager` for proper lifecycle management.
- **Fix zero-size view layout**: SWT 3.122.0 on macOS doesn't compute initial `SashForm` sash child sizes correctly with Eclipse 3.5.1 workbench, leaving all view containers at zero width/height until manually resized. Fixed by toggling the shell size in `postWindowOpen()` to force a relayout.
- **Force initial tree population**: Added `refresh()` and `expandToLevel(2)` after `setInput()` so tree items render immediately.

## Test plan
- [ ] Launch GeoCraft on macOS — all views (Repository, Properties, Log, Algorithms) should appear with correct sizes immediately without manual resizing
- [ ] Algorithms view should show 7 top-level categories (Attributes, Horizon, Interpretation, Programming Examples, Utilities, Velocity, Volume) with child items
- [ ] Double-clicking an algorithm leaf should open its editor
- [ ] Filter text box should filter algorithms by name
- [ ] No `SWT Resource was not properly disposed` errors in the console

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)