### PR TITLE
Fix OSGi startup errors: DS unbind signatures and missing icons

### DIFF
--- a/org.geocraft.core/src/org/geocraft/core/service/ServiceProvider.java
+++ b/org.geocraft.core/src/org/geocraft/core/service/ServiceProvider.java
@@ -73,7 +73,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unsetRepsitory() {
+  public synchronized void unsetRepsitory(final IRepository repository) {
     _repository = null;
   }
 
@@ -103,7 +103,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unsetLoggingService() {
+  public synchronized void unsetLoggingService(final ILoggingService loggingService) {
     _loggingService = null;
   }
 
@@ -133,7 +133,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unsetMessageService() {
+  public synchronized void unsetMessageService(final IMessageService messageService) {
     _messageService = null;
   }
 
@@ -163,7 +163,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unsetAlgorithmsService() {
+  public synchronized void unsetAlgorithmsService(final IAlgorithmsService algorithmService) {
     _algorithmService = null;
   }
 
@@ -193,7 +193,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unsetViewersService() {
+  public synchronized void unsetViewersService(final IViewersService viewerService) {
     _viewerService = null;
   }
 
@@ -223,7 +223,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unsetDatastoreAccessorService() {
+  public synchronized void unsetDatastoreAccessorService(final IDatastoreAccessorService datastoreAccessorService) {
     _datastoreAccessorService = null;
   }
 
@@ -253,7 +253,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unbindColorFormatService() {
+  public synchronized void unbindColorFormatService(final IColorFormatService colorFormatService) {
     _colorFormatService = null;
   }
 
@@ -283,7 +283,7 @@ public class ServiceProvider {
    * <p>
    * This is called automatically by OSGI.
    */
-  public synchronized void unbindColorMapService() {
+  public synchronized void unbindColorMapService(final IColorMapService colorMapService) {
     _colorMapService = null;
   }
 }

--- a/org.geocraft.io.las/build.properties
+++ b/org.geocraft.io.las/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               icons/

--- a/org.geocraft.ui.plot/build.properties
+++ b/org.geocraft.ui.plot/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = plugin.xml,\
                META-INF/,\
-               .
+               .,\
+               icons/

--- a/org.geocraft.ui.repository/build.properties
+++ b/org.geocraft.ui.repository/build.properties
@@ -3,3 +3,4 @@ output.. = bin/
 bin.includes = plugin.xml,\
                META-INF/,\
                .,\
+               icons/,\

--- a/org.geocraft.ui.traceviewer/build.properties
+++ b/org.geocraft.ui.traceviewer/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               icons/

--- a/org.geocraft.ui.viewer/build.properties
+++ b/org.geocraft.ui.viewer/build.properties
@@ -3,4 +3,5 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               OSGI-INF/component.xml
+               OSGI-INF/component.xml,\
+               icons/


### PR DESCRIPTION
## Summary
- Fix all 8 OSGi DS unbind methods in `ServiceProvider.java` to accept the service interface parameter, matching the bind method signatures. Without this, DS couldn't find the unbind methods via reflection, causing runtime errors.
- Add missing `icons/` to `bin.includes` in 5 bundle `build.properties` files (`ui.traceviewer`, `ui.repository`, `ui.plot`, `ui.viewer`, `io.las`) so icon resources are packaged in the bundle at runtime.

## Test plan
- [x] Launch GeoCraft and confirm no "unbind method not found" errors in console
- [x] Launch GeoCraft and confirm no `FileNotFoundException` for icon resources
- [x] Verify all core services initialize successfully
- [x] Verify clean error log (no error/warning entries in new session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)