### PR TITLE
Add developer quick start for clone → build → launch (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,29 +56,32 @@ Launch the built product:
 
 ### 2b. Build and Launch from the Eclipse IDE
 
+> **Use a fresh install of "Eclipse IDE for RCP and RAP Developers, 2025-12".** Reusing a previous Eclipse install that has the deprecated `org.sonatype.tycho.m2e` connector will cause hundreds of "Conflicting lifecycle mapping metadata" errors — see Troubleshooting.
+
 1. **Start Eclipse with a new workspace**:
    - Launch Eclipse IDE for RCP and RAP Developers (2025-12).
-   - When prompted for a workspace, pick a **new, empty directory** (e.g. `~/eclipse-workspaces/geocraft`). Do **not** pick the cloned `geocraft/` directory itself — Eclipse workspace metadata should live outside the source tree.
-   - Close the Welcome tab once Eclipse opens.
+   - When prompted for a workspace, pick a **new, empty directory** (e.g. `~/eclipse-workspaces/geocraft`). Do **not** pick the cloned `geocraft/` directory itself.
 2. **Import all projects into the workspace**:
    - `File > Import... > Maven > Existing Maven Projects`, click **Next**.
-   - Set **Root Directory** to the cloned `geocraft/` directory.
-   - Eclipse scans and lists every `pom.xml`. Leave all modules checked and click **Finish**.
-   - Wait for the initial Maven/M2E import and workspace build to finish (check the Progress view — this can take several minutes on first import).
-   - Expected result: all `org.geocraft.*` projects appear in the Package Explorer. At this point most projects will show compile errors because the target platform is not yet set — that is normal.
+   - Set **Root Directory** to the cloned `geocraft/` directory, leave all modules checked, click **Finish**.
+   - Wait for the initial Maven/M2E import to finish. Compile errors are expected until the target platform is set in step 3.
 3. **Configure the target platform**:
-   - In Package Explorer, expand `org.geocraft.target` and double-click `org.geocraft.target.target` to open the Target Editor.
-   - Click **Reload** (top right of the editor) and wait for all p2 locations to resolve. Resolution requires network access to `download.eclipse.org`.
-   - Once resolution completes with no errors, click **Set as Active Target Platform** (top right).
-   - Eclipse will trigger a workspace rebuild. Compile errors should clear. If they don't, run `Project > Clean... > Clean all projects`.
-4. **Create a run configuration and launch**:
-   - Open `org.geocraft.product/GeoCraft.product`.
-   - On the product editor **Overview** tab, click **Synchronize** to align the product's plug-in list with the target platform, then click **Launch an Eclipse application**. This creates a run configuration named after the product and launches GeoCraft.
-   - For subsequent launches, use `Run > Run Configurations... > Eclipse Application > GeoCraft.product` (or the Run toolbar dropdown).
-   - To tune the launch (VM args, workspace location, included plug-ins), edit the run configuration under `Run > Run Configurations...`.
+   - Double-click `org.geocraft.target/org.geocraft.target.target` to open the Target Editor.
+   - Click **Reload** (top right) and wait for all p2 locations to resolve (requires `download.eclipse.org` access).
+   - Click **Set as Active Target Platform** (top right).
+   - Eclipse rebuilds the workspace and the errors clear. If they don't, run `Project > Clean... > Clean all projects`.
+4. **Launch GeoCraft**:
+   - In Package Explorer, right-click `org.geocraft.product/GeoCraft.launch` > **Run As > GeoCraft**.
+   - Or: `Run > Run Configurations... > Eclipse Application > GeoCraft` > **Run**.
+   - The committed launch config (`GeoCraft.launch`) is feature-based and matches `GeoCraft.product`, so every algorithm and viewer bundle is loaded without manual plug-in selection.
 
 ### Troubleshooting
 
 - **Target platform fails to resolve**: ensure network access to `download.eclipse.org` (the p2 repositories listed in `pom.xml`).
 - **Tycho build fails on test bundles**: `testFailureIgnore` is set, but compilation errors still fail the build. Check the failing module's `pom.xml` and MANIFEST.MF.
 - **Launch fails with bundle resolution errors**: see `SWT_MIGRATION_LOG.md` for known issues and workarounds.
+- **Eclipse IDE — `Conflicting lifecycle mapping metadata ... org.sonatype.tycho.m2e` and hundreds of `does not have an expanded version` errors**: the deprecated `org.sonatype.tycho.m2e` connector conflicts with the modern `org.eclipse.m2e.pde.connector` bundled in Eclipse 2025-12 for RCP and RAP Developers. Uninstall the old one:
+  1. `Help > About Eclipse > Installation Details > Installed Software`.
+  2. Select **Tycho Project Configurators** (`org.sonatype.tycho.m2e`), click **Uninstall**, restart Eclipse.
+  3. Select all projects in Package Explorer, right-click > **Maven > Update Project...** (Alt+F5), click **OK**.
+- **Eclipse IDE — "An API baseline has not been set for the current workspace"**: non-blocking warning from PDE API Tools. Suppress via `Window > Preferences > Plug-in Development > API Errors/Warnings > General` tab, set **Missing API baseline** to **Ignore**.

--- a/README.md
+++ b/README.md
@@ -56,16 +56,26 @@ Launch the built product:
 
 ### 2b. Build and Launch from the Eclipse IDE
 
-1. **Set the target platform**:
-   - `File > Import > General > Existing Projects into Workspace` and select `org.geocraft.target`.
-   - Open `org.geocraft.target/org.geocraft.target.target`.
-   - Wait for it to resolve, then click **Set as Active Target Platform** (top right of the editor).
-2. **Import the remaining projects**:
-   - `File > Import > Maven > Existing Maven Projects`, select the cloned `geocraft` directory, and import all modules.
-3. **Build**: `Project > Build All` (or let autobuild run). Every bundle must compile cleanly before launch.
-4. **Run the product**:
+1. **Start Eclipse with a new workspace**:
+   - Launch Eclipse IDE for RCP and RAP Developers (2025-12).
+   - When prompted for a workspace, pick a **new, empty directory** (e.g. `~/eclipse-workspaces/geocraft`). Do **not** pick the cloned `geocraft/` directory itself — Eclipse workspace metadata should live outside the source tree.
+   - Close the Welcome tab once Eclipse opens.
+2. **Import all projects into the workspace**:
+   - `File > Import... > Maven > Existing Maven Projects`, click **Next**.
+   - Set **Root Directory** to the cloned `geocraft/` directory.
+   - Eclipse scans and lists every `pom.xml`. Leave all modules checked and click **Finish**.
+   - Wait for the initial Maven/M2E import and workspace build to finish (check the Progress view — this can take several minutes on first import).
+   - Expected result: all `org.geocraft.*` projects appear in the Package Explorer. At this point most projects will show compile errors because the target platform is not yet set — that is normal.
+3. **Configure the target platform**:
+   - In Package Explorer, expand `org.geocraft.target` and double-click `org.geocraft.target.target` to open the Target Editor.
+   - Click **Reload** (top right of the editor) and wait for all p2 locations to resolve. Resolution requires network access to `download.eclipse.org`.
+   - Once resolution completes with no errors, click **Set as Active Target Platform** (top right).
+   - Eclipse will trigger a workspace rebuild. Compile errors should clear. If they don't, run `Project > Clean... > Clean all projects`.
+4. **Create a run configuration and launch**:
    - Open `org.geocraft.product/GeoCraft.product`.
-   - Click **Launch an Eclipse application** (green play button) in the product editor overview page.
+   - On the product editor **Overview** tab, click **Synchronize** to align the product's plug-in list with the target platform, then click **Launch an Eclipse application**. This creates a run configuration named after the product and launches GeoCraft.
+   - For subsequent launches, use `Run > Run Configurations... > Eclipse Application > GeoCraft.product` (or the Run toolbar dropdown).
+   - To tune the launch (VM args, workspace location, included plug-ins), edit the run configuration under `Run > Run Configurations...`.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,65 @@ GeoCraft consists of:
 - simple visualization and data exploration tools
 
 GeoCraft is not designed to be a seismic data processing system, nor is it a replacement for seismic interpretation applications.
+
+## Developer Quick Start
+
+### Prerequisites
+
+- **JDK 21** (Temurin recommended). Verify with `java -version`.
+- **Maven 3.9+** (only required for Tycho command-line builds). Verify with `mvn -v`.
+- **Git**.
+- **Eclipse IDE for RCP and RAP Developers, 2025-12** (only required for in-IDE development).
+
+### 1. Clone
+
+```bash
+git clone https://github.com/laforge2001/geocraft.git
+cd geocraft
+```
+
+### 2a. Build and Launch via Tycho (command line)
+
+Builds every bundle, resolves the target platform from `org.geocraft.target/org.geocraft.target.target`, and assembles the product under `org.geocraft.repository/target/products/`.
+
+```bash
+mvn clean verify
+```
+
+Launch the built product:
+
+- **macOS (Apple Silicon)**:
+  ```bash
+  ./launch-geocraft.sh
+  ```
+  Or run the native app directly:
+  ```bash
+  open org.geocraft.repository/target/products/org.geocraft.product.product/macosx/cocoa/aarch64/Eclipse.app
+  ```
+- **Linux (x86_64)**:
+  ```bash
+  org.geocraft.repository/target/products/org.geocraft.product.product/linux/gtk/x86_64/eclipse
+  ```
+- **Windows (x86_64)**:
+  ```cmd
+  org.geocraft.repository\target\products\org.geocraft.product.product\win32\win32\x86_64\eclipse.exe
+  ```
+
+### 2b. Build and Launch from the Eclipse IDE
+
+1. **Set the target platform**:
+   - `File > Import > General > Existing Projects into Workspace` and select `org.geocraft.target`.
+   - Open `org.geocraft.target/org.geocraft.target.target`.
+   - Wait for it to resolve, then click **Set as Active Target Platform** (top right of the editor).
+2. **Import the remaining projects**:
+   - `File > Import > Maven > Existing Maven Projects`, select the cloned `geocraft` directory, and import all modules.
+3. **Build**: `Project > Build All` (or let autobuild run). Every bundle must compile cleanly before launch.
+4. **Run the product**:
+   - Open `org.geocraft.product/GeoCraft.product`.
+   - Click **Launch an Eclipse application** (green play button) in the product editor overview page.
+
+### Troubleshooting
+
+- **Target platform fails to resolve**: ensure network access to `download.eclipse.org` (the p2 repositories listed in `pom.xml`).
+- **Tycho build fails on test bundles**: `testFailureIgnore` is set, but compilation errors still fail the build. Check the failing module's `pom.xml` and MANIFEST.MF.
+- **Launch fails with bundle resolution errors**: see `SWT_MIGRATION_LOG.md` for known issues and workarounds.

--- a/org.geocraft.product/GeoCraft.launch
+++ b/org.geocraft.product/GeoCraft.launch
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+    <setAttribute key="additional_plugins"/>
+    <booleanAttribute key="append.args" value="true"/>
+    <stringAttribute key="application" value="org.geocraft.application"/>
+    <booleanAttribute key="askclear" value="true"/>
+    <booleanAttribute key="automaticAdd" value="false"/>
+    <booleanAttribute key="automaticIncludeRequirements" value="true"/>
+    <booleanAttribute key="automaticValidate" value="false"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="false"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/GeoCraft.product"/>
+    <booleanAttribute key="default" value="true"/>
+    <setAttribute key="deselected_workspace_bundles"/>
+    <stringAttribute key="featureDefaultLocation" value="workspace"/>
+    <stringAttribute key="featurePluginResolution" value="workspace"/>
+    <booleanAttribute key="includeOptional" value="true"/>
+    <stringAttribute key="location" value="${workspace_loc}/../runtime-GeoCraft.product"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms256m -Xmx1200m --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.geocraft.product.product"/>
+    <stringAttribute key="productFile" value="/org.geocraft.product/GeoCraft.product"/>
+    <stringAttribute key="productName" value="GeoCraft"/>
+    <setAttribute key="root_features"/>
+    <setAttribute key="selected_features">
+        <setEntry value="org.eclipse.help:default"/>
+        <setEntry value="org.eclipse.rcp:default"/>
+        <setEntry value="org.geocraft.abavo.feature:default"/>
+        <setEntry value="org.geocraft.feature:default"/>
+        <setEntry value="org.geocraft.geomath.feature:default"/>
+        <setEntry value="org.geocraft.ui.viewer.feature:default"/>
+    </setAttribute>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <stringAttribute key="templateConfig" value="${workspace_loc:/org.geocraft.product/config.ini}"/>
+    <booleanAttribute key="useCustomFeatures" value="true"/>
+    <booleanAttribute key="useDefaultConfig" value="false"/>
+    <booleanAttribute key="useDefaultConfigArea" value="true"/>
+    <booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>


### PR DESCRIPTION
## Summary

Closes #31.

- Document a "Developer Quick Start" in `README.md`: prerequisites (JDK 21, Maven 3.9+, Git, Eclipse 2025-12 RCP), clone, Tycho command-line path (`mvn clean verify` + per-platform launch), and Eclipse IDE path (new workspace → import Maven projects → set target platform → run).
- Commit `org.geocraft.product/GeoCraft.launch` so Eclipse users can launch via **Run As > GeoCraft** without hand-configuring a run configuration. The launch config is feature-based (`useCustomFeatures=true`), matches every feature in `GeoCraft.product`, and sets `automaticIncludeRequirements=true` so algorithm and viewer bundles load without manual plug-in selection.
- Track `org.geocraft.rendering.jogl.tests/test-resources/golden/` via `.gitkeep` so fresh clones don't fail `mvn clean verify` with `bin.includes value(s) [test-resources/] do not match any files`.
- Troubleshooting section calls out the common Eclipse install conflict: the deprecated `org.sonatype.tycho.m2e` connector must be uninstalled to avoid "Conflicting lifecycle mapping metadata" errors with the bundled `org.eclipse.m2e.pde.connector` in Eclipse 2025-12.
- GitHub repo description set to a concise tagline pointing at the README.

Known section viewer / plot crash on macOS is tracked separately in #33 — out of scope for this PR.

## Test plan

- [x] `mvn clean verify` succeeds on macOS Apple Silicon (Temurin 21) with a fresh clone.
- [x] Eclipse IDE quick start works end-to-end: fresh workspace, Maven import, target platform activation, launch via `GeoCraft.launch` loads all features with no manual plug-in selection.
- [x] `.gitkeep` makes `test-resources/` present in fresh clones (`git ls-files` includes the file).
- [ ] Reviewer spot-checks the Troubleshooting section matches their environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)