### PR TITLE
Fix 3D viewer black + slow render on macOS aarch64 (#35)

### DIFF
--- a/SWT_MIGRATION_LOG.md
+++ b/SWT_MIGRATION_LOG.md
@@ -320,3 +320,141 @@ hands back an NSBitmapImageRep with a pixel stride the CoreGraphics
 bitmap in Java with a known 24-bit RGB layout; SWT wraps it in an
 NSBitmapImageRep whose buffer stride matches CG's expectation, so the
 first `fillRectangle` inside `clearGraphics` no longer crashes.
+
+## Symptom 4 — 3D viewer black, then Section Viewer also black (issue #35, 2026-04-18)
+
+### Reproduction
+1. Launch GeoCraft on macOS Apple Silicon (Eclipse 2025-12 PDE or `launch-geocraft.sh`) after the #33 SIGSEGV fix.
+2. Generate test data, open Section Viewer — renders correctly.
+3. Open 3D Viewer on the same dataset — canvas is entirely black.
+4. Switch back to the Section Viewer — plot area now also black; further paints do not update it.
+
+### Investigation
+- `ViewCanvasImplementor.render()` silently skipped rendering if `_backend`
+  wasn't a `JoglRenderBackend`. `ViewCanvasFactory.lookupRenderBackend()`
+  returned `null` without logging when the OSGi service was missing. The
+  legacy `JoglRenderBackend.renderPass(GroupNode, ...)` path swallowed
+  every exception. The failure mode — "canvas draws nothing" — had no
+  runtime signal anywhere.
+- `JoglSwtCanvas` constructs a NEWT `GLWindow` inside a `NewtCanvasSWT`
+  with `newtCanvas.setVisible(false)`. `ViewCanvasImplementor`'s constructor
+  then called `canvas.startAnimator(30, ...)` immediately, so the
+  `FPSAnimator` began calling `display()` against a hidden NSOpenGLView
+  before the canvas was ever shown.
+- Under `-XstartOnFirstThread` SWT owns the AppKit main thread, but the
+  FPSAnimator's dedicated render thread holds the CGLContext continuously.
+  When the user switches to a sibling part (Section Viewer), SWT's
+  `ModelSpaceCanvas.paintControlCustom()` GC blits fire but the IOSurface
+  backing the NSView never updates — the plot stays black.
+- The viewer was never telling the FPSAnimator to pause when hidden or
+  disposed, and never destroying the NEWT `GLWindow` on close, so the
+  cascade persisted until the JVM exited.
+
+### Fix
+Scoped changes in `org.geocraft.ui.volumeviewer` and `org.geocraft.rendering.jogl`:
+
+- `ViewCanvasFactory.lookupRenderBackend()` now logs a `WARN` on every
+  null path (missing `BundleContext`, missing `ServiceReference`, catch
+  block). A second `WARN` in `ViewCanvasFactory.makeCanvas()` names the
+  failure mode ("3D viewer canvas will render black"). Silent failure
+  is gone.
+- `ViewCanvasImplementor.render()` wraps the `JoglRenderBackend.renderPass`
+  call in a try/catch that logs once per canvas, and emits a one-shot
+  `WARN` if `_backend` isn't a `JoglRenderBackend`.
+- `JoglRenderBackend.renderPass(GroupNode, ...)` now logs the first
+  swallowed exception via `java.util.logging.Logger` instead of silently
+  continuing.
+- `JoglSwtCanvas.startAnimator()` registers the `GLEventListener` and
+  constructs the `FPSAnimator` but defers `animator.start()` until the
+  first `setContentVisible(true)` call. `setContentVisible()` drives
+  the full lifecycle (start → pause on hide → resume on show).
+  `pauseAnimator()` / `resumeAnimator()` are exposed for part-lifecycle
+  hooks. `dispose()` unconditionally stops the animator, nulls the
+  reference, and destroys the `GLWindow`.
+- `VolumeViewer` registers an `IPartListener2` against its
+  `IWorkbenchPartSite`'s page. `partHidden` pauses the render loop and
+  schedules a recursive `redraw()+update()` over every SWT `Control` in
+  every open `Shell`, forcing Cocoa to re-acquire each NSView's
+  IOSurface. `partVisible` resumes the animator. `dispose()` removes
+  the listener, calls `canvas.dispose()` before `super.dispose()` (so
+  the render thread ends before the parent Composite is torn down), and
+  triggers one more sibling-redraw pass for good measure.
+
+### What we did not change
+- Did not migrate from NEWT+`NewtCanvasSWT` to `com.jogamp.opengl.swt.GLCanvas`.
+  The JOGL SWT GLCanvas still has a DPIUtil API mismatch with Eclipse
+  2025-12's SWT (documented in `SWT_MIGRATION_LOG.md` Symptom 3), so
+  NEWT remains the only working path on macOS aarch64.
+- Did not touch the stubbed `Grid3dRenderer` / `FaultRenderer` /
+  `WellRenderer` renderers. `PostStack3dRenderer` is functional and
+  exercises the whole pipeline; the Ardor3D → JOGL port of the others
+  is tracked separately (see `project_jogl_migration_status` memory).
+
+### Post-fix diagnostic + real root cause
+
+After the first round of changes above, the 3D viewer was still rendering
+black. The new log in `.metadata/.log` was decisive:
+
+```
+!ENTRY org.geocraft.ui.volumeviewer 2 0 2026-04-18 17:16:10.210
+!MESSAGE RenderBackend service reference not found in OSGi registry.
+!ENTRY org.geocraft.ui.volumeviewer 2 0 2026-04-18 17:16:10.210
+!MESSAGE No RenderBackend OSGi service registered — 3D viewer canvas will render black. ...
+!ENTRY org.geocraft.ui.volumeviewer 2 0 2026-04-18 17:16:10.920
+!MESSAGE 3D viewer has no JoglRenderBackend (got null) — canvas will render black.
+```
+
+The backend service literally wasn't in the OSGi registry. Comparing the
+`org.geocraft.rendering.jogl` MANIFEST to other DS-providing bundles in
+the project (`org.geocraft.core`, `org.geocraft.algorithm`,
+`org.geocraft.ui.viewer`) showed the missing line:
+
+```
+Bundle-ActivationPolicy: lazy
+```
+
+Without lazy activation, `rendering.jogl` sat in `RESOLVED` state in PDE
+dev launches. The `immediate="true"` flag on the DS component only fires
+once the owning bundle has transitioned to `STARTING`/`ACTIVE`, so the
+service was never published. `selected_workspace_bundles` in
+`GeoCraft.launch` uses `@default:default` (no auto-start), so the bundle
+only ever started if something forced it — and nothing did.
+
+### Second fix
+
+- `org.geocraft.rendering.jogl/META-INF/MANIFEST.MF`: added
+  `Bundle-ActivationPolicy: lazy`. Now the first class load out of any
+  exported package transitions the bundle to `STARTING`, the DS runtime
+  activates the `JoglRenderBackend` component, and the service is
+  registered.
+- `ViewCanvasFactory.makeCanvas()`: construct the `JoglSwtCanvas` *before*
+  calling `lookupRenderBackend()`. `JoglSwtCanvas` is the first class
+  load from `org.geocraft.rendering.jogl`, so this ordering guarantees
+  that lazy activation has already fired by the time the service lookup
+  runs. Without the reorder, the OSGi lookup would race the bundle
+  transition and return `null`.
+
+### Performance fix
+
+After the DS activation fix above, the 3D viewer rendered correctly but
+was unusably slow on any realistic seismic volume. The `JoglGeometryUpload`
+port from Ardor3D used immediate-mode `glBegin`/`glEnd` with per-vertex
+`glVertex3f`/`glNormal3f`/`glColor4f`/`glTexCoord2f` — roughly 12 JNI
+boundary crossings per triangle, then multiplied by 30 fps.
+
+- `JoglGeometryUpload.drawMesh` / `drawLine` now use client-side vertex
+  arrays (`glEnableClientState` + `glVertexPointer`/`glNormalPointer`/…
+  + `glDrawElements`/`glDrawArrays`). One JNI trip per mesh.
+- JOGL's vertex-array API requires *direct* NIO buffers. Renderers in
+  the project build geometry with `FloatBuffer.allocate(...)` (heap
+  buffers), which made `glVertexPointer` throw
+  `"Argument 'ptr' is not a direct buffer"`. Defense in depth:
+  - `JoglGeometryUpload` keeps identity-keyed `IdentityHashMap` caches
+    that transparently copy any heap buffer into a direct buffer on
+    first use. Cheap — meshes are static, so the copy happens once.
+  - `PostStack3dRenderer.buildSliceGrid` and the bounding-box packer
+    now allocate their buffers via
+    `ByteBuffer.allocateDirect(n * 4).order(nativeOrder()).asFloatBuffer()`
+    from the start, so no copy is needed on the hot path.
+- `JoglGeometryUpload.drawSphere` now caches its `GLU` + `GLUquadric`
+  instead of allocating + disposing per frame.

--- a/org.geocraft.rendering.jogl/META-INF/MANIFEST.MF
+++ b/org.geocraft.rendering.jogl/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Import-Package: org.joml,
  com.jogamp.newt.swt
 Export-Package: org.geocraft.rendering.jogl
 Service-Component: OSGI-INF/JoglRenderBackend.xml
+Bundle-ActivationPolicy: lazy

--- a/org.geocraft.rendering.jogl/src/org/geocraft/rendering/jogl/JoglGeometryUpload.java
+++ b/org.geocraft.rendering.jogl/src/org/geocraft/rendering/jogl/JoglGeometryUpload.java
@@ -1,71 +1,142 @@
 package org.geocraft.rendering.jogl;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
+import java.util.IdentityHashMap;
 import com.jogamp.opengl.GL;
 import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.fixedfunc.GLPointerFunc;
 import org.geocraft.core.rendering.scene.LineGeometry;
 import org.geocraft.core.rendering.scene.MeshGeometry;
 import org.geocraft.core.rendering.scene.SphereGeometry;
 import org.joml.Vector4f;
 
+/**
+ * Pushes scene-graph geometry through the GL2 fixed-function pipeline using
+ * client-side vertex arrays. Each mesh is drawn with a single
+ * {@code glDrawElements} / {@code glDrawArrays} call (one JNI boundary crossing)
+ * rather than the per-vertex {@code glVertex3f} immediate-mode pattern that
+ * the Ardor3D → JOGL port started with — which made the 3D viewer unusably
+ * slow on large seismic volumes (~10⁵ triangles × 30 fps × 10+ GL calls per
+ * vertex = tens of millions of JNI trips per second).
+ */
 public class JoglGeometryUpload {
 
+    private com.jogamp.opengl.glu.GLU glu;
+    private com.jogamp.opengl.glu.GLUquadric sphereQuadric;
+
+    // JOGL's client-side vertex-array API requires direct NIO buffers (it
+    // hands a raw native pointer to the GL driver). Many renderers allocate
+    // via FloatBuffer.allocate(...) which is a heap buffer — that throws
+    // "Argument 'ptr' is not a direct buffer" at draw time. We transparently
+    // copy heap buffers into a cached direct buffer on first use. Keyed by
+    // identity because FloatBuffer.equals walks the whole content.
+    private final IdentityHashMap<FloatBuffer, FloatBuffer> directFloatCache = new IdentityHashMap<>();
+    private final IdentityHashMap<IntBuffer, IntBuffer> directIntCache = new IdentityHashMap<>();
+
+    private FloatBuffer ensureDirect(FloatBuffer src) {
+        if (src == null || src.isDirect()) return src;
+        FloatBuffer cached = directFloatCache.get(src);
+        if (cached != null && cached.capacity() == src.capacity()) {
+            cached.clear();
+            src.rewind();
+            cached.put(src);
+            cached.rewind();
+            return cached;
+        }
+        FloatBuffer direct = ByteBuffer.allocateDirect(src.capacity() * Float.BYTES)
+            .order(ByteOrder.nativeOrder()).asFloatBuffer();
+        src.rewind();
+        direct.put(src);
+        direct.rewind();
+        directFloatCache.put(src, direct);
+        return direct;
+    }
+
+    private IntBuffer ensureDirect(IntBuffer src) {
+        if (src == null || src.isDirect()) return src;
+        IntBuffer cached = directIntCache.get(src);
+        if (cached != null && cached.capacity() == src.capacity()) {
+            cached.clear();
+            src.rewind();
+            cached.put(src);
+            cached.rewind();
+            return cached;
+        }
+        IntBuffer direct = ByteBuffer.allocateDirect(src.capacity() * Integer.BYTES)
+            .order(ByteOrder.nativeOrder()).asIntBuffer();
+        src.rewind();
+        direct.put(src);
+        direct.rewind();
+        directIntCache.put(src, direct);
+        return direct;
+    }
+
     public void drawMesh(GL2 gl, MeshGeometry mesh) {
-        FloatBuffer v = mesh.getVertices();
-        FloatBuffer n = mesh.getNormals();
-        FloatBuffer uv = mesh.getTexCoords();
-        FloatBuffer colors = mesh.getColors();
-        IntBuffer idx = mesh.getIndices();
+        FloatBuffer v = ensureDirect(mesh.getVertices());
         if (v == null) return;
+        FloatBuffer n = ensureDirect(mesh.getNormals());
+        FloatBuffer uv = ensureDirect(mesh.getTexCoords());
+        FloatBuffer colors = ensureDirect(mesh.getColors());
+        IntBuffer idx = ensureDirect(mesh.getIndices());
         v.rewind();
         if (n != null) n.rewind();
         if (uv != null) uv.rewind();
         if (colors != null) colors.rewind();
         if (idx != null) idx.rewind();
 
-        gl.glBegin(GL.GL_TRIANGLES);
-        int triCount = idx != null ? mesh.getTriangleCount() : mesh.getVertexCount() / 3;
-        for (int t = 0; t < triCount; t++) {
-            for (int k = 0; k < 3; k++) {
-                int i = idx != null ? idx.get(t * 3 + k) : (t * 3 + k);
-                if (n != null) gl.glNormal3f(n.get(i * 3), n.get(i * 3 + 1), n.get(i * 3 + 2));
-                if (colors != null) gl.glColor4f(colors.get(i * 4), colors.get(i * 4 + 1), colors.get(i * 4 + 2), colors.get(i * 4 + 3));
-                if (uv != null) gl.glTexCoord2f(uv.get(i * 2), uv.get(i * 2 + 1));
-                gl.glVertex3f(v.get(i * 3), v.get(i * 3 + 1), v.get(i * 3 + 2));
-            }
+        gl.glEnableClientState(GLPointerFunc.GL_VERTEX_ARRAY);
+        gl.glVertexPointer(3, GL.GL_FLOAT, 0, v);
+        if (n != null) {
+            gl.glEnableClientState(GLPointerFunc.GL_NORMAL_ARRAY);
+            gl.glNormalPointer(GL.GL_FLOAT, 0, n);
         }
-        gl.glEnd();
+        if (colors != null) {
+            gl.glEnableClientState(GLPointerFunc.GL_COLOR_ARRAY);
+            gl.glColorPointer(4, GL.GL_FLOAT, 0, colors);
+        }
+        if (uv != null) {
+            gl.glEnableClientState(GLPointerFunc.GL_TEXTURE_COORD_ARRAY);
+            gl.glTexCoordPointer(2, GL.GL_FLOAT, 0, uv);
+        }
+
+        if (idx != null) {
+            gl.glDrawElements(GL.GL_TRIANGLES, mesh.getTriangleCount() * 3, GL.GL_UNSIGNED_INT, idx);
+        } else {
+            gl.glDrawArrays(GL.GL_TRIANGLES, 0, (mesh.getVertexCount() / 3) * 3);
+        }
+
+        gl.glDisableClientState(GLPointerFunc.GL_VERTEX_ARRAY);
+        if (n != null) gl.glDisableClientState(GLPointerFunc.GL_NORMAL_ARRAY);
+        if (colors != null) gl.glDisableClientState(GLPointerFunc.GL_COLOR_ARRAY);
+        if (uv != null) gl.glDisableClientState(GLPointerFunc.GL_TEXTURE_COORD_ARRAY);
     }
 
     public void drawLine(GL2 gl, LineGeometry line) {
-        FloatBuffer v = line.getVertices();
+        FloatBuffer v = ensureDirect(line.getVertices());
         if (v == null || line.getVertexCount() == 0) return;
         v.rewind();
         Vector4f c = line.getColor();
         gl.glLineWidth(line.getLineWidth());
         gl.glColor4f(c.x, c.y, c.z, c.w);
         gl.glDisable(GL.GL_TEXTURE_2D);
-        gl.glBegin(GL.GL_LINES);
-        for (int i = 0; i < line.getVertexCount(); i++) {
-            // Pull into locals: Java doesn't guarantee argument evaluation
-            // order relative to side effects on the FloatBuffer position.
-            float x = v.get();
-            float y = v.get();
-            float z = v.get();
-            gl.glVertex3f(x, y, z);
-        }
-        gl.glEnd();
-        v.rewind();
+
+        gl.glEnableClientState(GLPointerFunc.GL_VERTEX_ARRAY);
+        gl.glVertexPointer(3, GL.GL_FLOAT, 0, v);
+        gl.glDrawArrays(GL.GL_LINES, 0, line.getVertexCount());
+        gl.glDisableClientState(GLPointerFunc.GL_VERTEX_ARRAY);
     }
 
     public void drawSphere(GL2 gl, SphereGeometry sphere) {
-        // Simple icosphere-like approximation via GLU quadric
-        com.jogamp.opengl.glu.GLU glu = new com.jogamp.opengl.glu.GLU();
-        com.jogamp.opengl.glu.GLUquadric q = glu.gluNewQuadric();
+        // Cache the GLU + quadric — the previous implementation allocated
+        // a fresh quadric and deleted it every frame, which is both GC
+        // pressure and driver overhead.
+        if (glu == null) glu = new com.jogamp.opengl.glu.GLU();
+        if (sphereQuadric == null) sphereQuadric = glu.gluNewQuadric();
         Vector4f c = sphere.getColor();
         gl.glColor4f(c.x, c.y, c.z, c.w);
-        glu.gluSphere(q, sphere.getRadius(), 16, 16);
-        glu.gluDeleteQuadric(q);
+        glu.gluSphere(sphereQuadric, sphere.getRadius(), 16, 16);
     }
 }

--- a/org.geocraft.rendering.jogl/src/org/geocraft/rendering/jogl/JoglRenderBackend.java
+++ b/org.geocraft.rendering.jogl/src/org/geocraft/rendering/jogl/JoglRenderBackend.java
@@ -2,6 +2,8 @@ package org.geocraft.rendering.jogl;
 
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import com.jogamp.opengl.GL;
 import com.jogamp.opengl.GL2;
 import com.jogamp.opengl.GLContext;
@@ -23,10 +25,13 @@ import org.joml.Matrix4f;
  * makeCurrent/release ourselves.
  */
 public class JoglRenderBackend implements RenderBackend {
+    private static final Logger LOG = Logger.getLogger(JoglRenderBackend.class.getName());
+
     private final JoglSceneWalker walker = new JoglSceneWalker();
     private final JoglTextureLoader textureLoader = new JoglTextureLoader();
     private final float[] _matrixBuf = new float[16];
     private RenderSurface currentSurface;
+    private boolean nonNewtErrorLogged;
 
     @Override
     public void initialize(RenderSurface surface) {
@@ -71,7 +76,13 @@ public class JoglRenderBackend implements RenderBackend {
             GL2 gl = GLContext.getCurrentGL().getGL2();
             renderPass(gl, root, camera, lights, overrideMaterial);
         } catch (Exception e) {
-            // swallow render errors; surface may be transiently unavailable
+            // Log once — transient surface unavailability shouldn't spam, but
+            // silent swallowing masked the root cause of the 3D-black regression
+            // reported in issue #35.
+            if (!nonNewtErrorLogged) {
+                nonNewtErrorLogged = true;
+                LOG.log(Level.WARNING, "JoglRenderBackend render pass failed (non-NEWT path): " + e.getMessage(), e);
+            }
         } finally {
             currentSurface.release();
         }

--- a/org.geocraft.rendering.jogl/src/org/geocraft/rendering/jogl/JoglSwtCanvas.java
+++ b/org.geocraft.rendering.jogl/src/org/geocraft/rendering/jogl/JoglSwtCanvas.java
@@ -79,6 +79,8 @@ public class JoglSwtCanvas implements RenderSurface {
     private volatile int cachedWidth;
     private volatile int cachedHeight;
     private FPSAnimator animator;
+    private boolean animatorPendingStart;
+    private boolean contentVisible;
 
     public JoglSwtCanvas(Composite parent) {
         ensureNativesConfigured();
@@ -92,11 +94,48 @@ public class JoglSwtCanvas implements RenderSurface {
         newtCanvas.setVisible(false);
     }
 
-    /** Show or hide the NEWT canvas. Hidden by default to prevent the
-     *  GL window from taking over the workbench on startup. */
+    /**
+     * Show or hide the NEWT canvas. Hidden by default to prevent the
+     * GL window from taking over the workbench on startup.
+     *
+     * Also drives the FPSAnimator lifecycle: starting it only once the
+     * NSOpenGLView is visible avoids the Apple Silicon failure mode
+     * where the animator renders into a hidden surface and the CGLContext
+     * escapes AppKit's pipeline (seen as black 3D canvas and subsequent
+     * black Section Viewer plot under -XstartOnFirstThread).
+     */
     public void setContentVisible(boolean visible) {
-        if (!newtCanvas.isDisposed()) {
-            newtCanvas.setVisible(visible);
+        if (newtCanvas.isDisposed()) return;
+        newtCanvas.setVisible(visible);
+        contentVisible = visible;
+        if (animator == null) return;
+        if (visible) {
+            if (animatorPendingStart) {
+                animator.start();
+                animatorPendingStart = false;
+            } else if (animator.isPaused()) {
+                animator.resume();
+            }
+        } else if (animator.isAnimating() && !animator.isPaused()) {
+            animator.pause();
+        }
+    }
+
+    /** Pause the render loop — used when the containing workbench part is hidden. */
+    public void pauseAnimator() {
+        if (animator != null && animator.isAnimating() && !animator.isPaused()) {
+            animator.pause();
+        }
+    }
+
+    /** Resume the render loop — used when the containing workbench part is revealed. */
+    public void resumeAnimator() {
+        if (animator == null) return;
+        if (animatorPendingStart && contentVisible) {
+            animator.start();
+            animatorPendingStart = false;
+        } else if (animator.isPaused()) {
+            animator.resume();
         }
     }
 
@@ -111,7 +150,14 @@ public class JoglSwtCanvas implements RenderSurface {
     }
 
     /**
-     * Set up a GLEventListener and start an FPSAnimator at the given rate.
+     * Register a GLEventListener and prepare an FPSAnimator at the given rate.
+     * The animator is NOT started immediately — it starts on the first
+     * {@link #setContentVisible(boolean) setContentVisible(true)} call, once
+     * the NSOpenGLView backing the canvas is actually visible. This avoids
+     * JOGL rendering into an unmapped surface under -XstartOnFirstThread on
+     * macOS, which was observed to corrupt the shared AppKit GL context and
+     * cascade a black Section Viewer plot (issue #35).
+     *
      * The callback methods receive an already-current GL2 context.
      */
     public void startAnimator(int fps, RenderCallback callback) {
@@ -132,7 +178,11 @@ public class JoglSwtCanvas implements RenderSurface {
             @Override public void dispose(GLAutoDrawable d) { }
         });
         animator = new FPSAnimator(glWindow, fps);
-        animator.start();
+        animatorPendingStart = true;
+        if (contentVisible) {
+            animator.start();
+            animatorPendingStart = false;
+        }
     }
 
     /** Get the SWT control for layout purposes. */
@@ -237,9 +287,18 @@ public class JoglSwtCanvas implements RenderSurface {
 
     @Override public void dispose() {
         // Stop the animator first so its render thread doesn't try to call
-        // display() on a destroyed GLWindow.
-        if (animator != null && animator.isAnimating()) {
-            animator.stop();
+        // display() on a destroyed GLWindow. Also unconditionally stop so a
+        // paused animator doesn't leak a dormant render thread after close,
+        // which on macOS can keep the CGLContext pinned and starve SWT's
+        // main-thread paint loop (issue #35).
+        if (animator != null) {
+            try {
+                animator.stop();
+            } catch (Throwable t) {
+                // Animator may already be torn down — ignore.
+            }
+            animator = null;
+            animatorPendingStart = false;
         }
         glWindow.destroy();
         if (!newtCanvas.isDisposed()) {

--- a/org.geocraft.ui.volumeviewer/src/org/geocraft/internal/ui/volumeviewer/canvas/ViewCanvasFactory.java
+++ b/org.geocraft.ui.volumeviewer/src/org/geocraft/internal/ui/volumeviewer/canvas/ViewCanvasFactory.java
@@ -6,6 +6,8 @@ package org.geocraft.internal.ui.volumeviewer.canvas;
 
 import org.eclipse.swt.widgets.Composite;
 import org.geocraft.core.rendering.backend.RenderBackend;
+import org.geocraft.core.service.ServiceProvider;
+import org.geocraft.core.service.logging.ILogger;
 import org.geocraft.rendering.jogl.JoglSwtCanvas;
 import org.geocraft.rendering.jogl.SwtInputAdapter;
 import org.geocraft.ui.volumeviewer.IVolumeViewer;
@@ -16,12 +18,26 @@ import org.osgi.framework.ServiceReference;
 
 public class ViewCanvasFactory {
 
+  private static final ILogger LOGGER = ServiceProvider.getLoggingService().getLogger(ViewCanvasFactory.class);
+
   public static ViewCanvasImplementor makeCanvas(final Composite canvasComposite,
       final IVolumeViewer viewer, final int depthBits) {
 
-    final RenderBackend backend = lookupRenderBackend();
-
+    // Construct the JoglSwtCanvas *before* looking up the RenderBackend
+    // service. Referencing JoglSwtCanvas is the first class load out of
+    // the org.geocraft.rendering.jogl bundle, which triggers its lazy
+    // activation (Bundle-ActivationPolicy: lazy). Lazy activation is what
+    // causes Declarative Services to publish the JoglRenderBackend service.
+    // If we looked up the service first, the bundle would still be in
+    // RESOLVED state, the DS component would not yet be active, and the
+    // lookup would return null — the exact failure observed in issue #35.
     final JoglSwtCanvas canvas = new JoglSwtCanvas(canvasComposite);
+
+    final RenderBackend backend = lookupRenderBackend();
+    if (backend == null) {
+      LOGGER.warn("No RenderBackend OSGi service registered — 3D viewer canvas will render black. "
+          + "Check that org.geocraft.rendering.jogl bundle is active and its DS component started.");
+    }
 
     if (backend != null) {
       backend.initialize(canvas);
@@ -35,11 +51,18 @@ public class ViewCanvasFactory {
   private static RenderBackend lookupRenderBackend() {
     try {
       final BundleContext ctx = FrameworkUtil.getBundle(ViewCanvasFactory.class).getBundleContext();
-      if (ctx == null) return null;
+      if (ctx == null) {
+        LOGGER.warn("ViewCanvasFactory has no BundleContext — RenderBackend lookup skipped.");
+        return null;
+      }
       final ServiceReference<RenderBackend> ref = ctx.getServiceReference(RenderBackend.class);
-      if (ref == null) return null;
+      if (ref == null) {
+        LOGGER.warn("RenderBackend service reference not found in OSGi registry.");
+        return null;
+      }
       return ctx.getService(ref);
     } catch (final Exception e) {
+      LOGGER.error("Failed to look up RenderBackend OSGi service: " + e.getMessage(), e);
       return null;
     }
   }

--- a/org.geocraft.ui.volumeviewer/src/org/geocraft/internal/ui/volumeviewer/canvas/ViewCanvasImplementor.java
+++ b/org.geocraft.ui.volumeviewer/src/org/geocraft/internal/ui/volumeviewer/canvas/ViewCanvasImplementor.java
@@ -20,6 +20,8 @@ import org.geocraft.core.rendering.pick.PickResult;
 import org.geocraft.core.rendering.pick.Ray;
 import org.geocraft.core.rendering.scene.GroupNode;
 import org.geocraft.core.rendering.scene.SceneNode;
+import org.geocraft.core.service.ServiceProvider;
+import org.geocraft.core.service.logging.ILogger;
 import org.geocraft.internal.ui.volumeviewer.input.VolumeMouseLook;
 import org.geocraft.internal.ui.volumeviewer.widget.FocusRods;
 import org.geocraft.internal.ui.volumeviewer.widget.FocusRods.ShowMode;
@@ -44,10 +46,14 @@ import org.joml.Vector4f;
  */
 public class ViewCanvasImplementor {
 
+  private static final ILogger LOGGER = ServiceProvider.getLoggingService().getLogger(ViewCanvasImplementor.class);
+
   private final RenderBackend _backend;
   private final JoglSwtCanvas _canvas;
   private final SwtInputAdapter _inputAdapter;
   private final IVolumeViewer _view;
+  private boolean _missingBackendWarned;
+  private boolean _renderErrorLogged;
 
   private final GroupNode _rootNode = new GroupNode("root");
   private final GroupNode _wireoverRoot = new GroupNode("wireover");
@@ -434,9 +440,22 @@ public class ViewCanvasImplementor {
 
     // Render the scene via the JoglRenderBackend. If no backend is available
     // (e.g. OSGi service not registered in PDE dev mode), the canvas will
-    // remain black — no fallback path.
+    // remain black — no fallback path. Warn once per canvas so the failure
+    // mode is not silent (issue #35).
     if (_backend instanceof JoglRenderBackend) {
-      ((JoglRenderBackend) _backend).renderPass(gl, _rootNode, _camera, _lights, null);
+      try {
+        ((JoglRenderBackend) _backend).renderPass(gl, _rootNode, _camera, _lights, null);
+      } catch (final Throwable t) {
+        if (!_renderErrorLogged) {
+          _renderErrorLogged = true;
+          LOGGER.error("3D viewer render pass threw: " + t.getMessage(), t);
+        }
+      }
+    } else if (!_missingBackendWarned) {
+      _missingBackendWarned = true;
+      LOGGER.warn("3D viewer has no JoglRenderBackend (got "
+          + (_backend == null ? "null" : _backend.getClass().getName())
+          + ") — canvas will render black.");
     }
   }
 

--- a/org.geocraft.ui.volumeviewer/src/org/geocraft/ui/volumeviewer/VolumeViewer.java
+++ b/org.geocraft.ui.volumeviewer/src/org/geocraft/ui/volumeviewer/VolumeViewer.java
@@ -22,9 +22,13 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PlatformUI;
 import org.geocraft.core.common.progress.BackgroundTask;
@@ -122,6 +126,12 @@ public class VolumeViewer extends AbstractDataViewer implements IVolumeViewer, I
   /** The number of opened 3d viewers. */
   private static int _openedViewers;
 
+  /** Part-lifecycle listener that pauses the JOGL render loop when the
+   *  3D viewer workbench part is hidden, and resumes it when revealed.
+   *  Prevents the FPSAnimator from holding the macOS CGLContext while
+   *  the user has switched to a sibling view (issue #35). */
+  private IPartListener2 _partListener;
+
   public VolumeViewer(final Composite parent, final IWorkbenchPartSite site) {
     super(parent, false, false, true);
     _site = site;
@@ -149,7 +159,80 @@ public class VolumeViewer extends AbstractDataViewer implements IVolumeViewer, I
     _viewerPropertyListener = new VolumeViewerPropertyListener(this, _store);
     _store.addPropertyChangeListener(_viewerPropertyListener);
 
+    registerPartLifecycleListener();
+
     _openedViewers++;
+  }
+
+  /**
+   * Register a workbench part listener so the JOGL render loop is paused
+   * when the 3D viewer tab is hidden and resumed when revealed. On macOS
+   * under -XstartOnFirstThread, a continuously-running FPSAnimator on a
+   * hidden tab keeps hold of the CGLContext and starves SWT's main-thread
+   * paint for sibling views (observed in issue #35 as the Section Viewer
+   * going black after the 3D Viewer was opened).
+   */
+  private void registerPartLifecycleListener() {
+    if (_site == null || _site.getPage() == null) return;
+    _partListener = new IPartListener2() {
+      @Override public void partActivated(final IWorkbenchPartReference ref) { /* no-op */ }
+      @Override public void partBroughtToTop(final IWorkbenchPartReference ref) { /* no-op */ }
+      @Override public void partClosed(final IWorkbenchPartReference ref) { /* no-op */ }
+      @Override public void partDeactivated(final IWorkbenchPartReference ref) { /* no-op */ }
+      @Override public void partOpened(final IWorkbenchPartReference ref) { /* no-op */ }
+      @Override public void partInputChanged(final IWorkbenchPartReference ref) { /* no-op */ }
+      @Override public void partHidden(final IWorkbenchPartReference ref) {
+        if (isOurPart(ref) && _viewCanvasImpl != null && _viewCanvasImpl.getCanvas() != null) {
+          _viewCanvasImpl.getCanvas().pauseAnimator();
+          redrawSiblingPlotCanvases();
+        }
+      }
+      @Override public void partVisible(final IWorkbenchPartReference ref) {
+        if (isOurPart(ref) && _viewCanvasImpl != null && _viewCanvasImpl.getCanvas() != null) {
+          _viewCanvasImpl.getCanvas().resumeAnimator();
+        }
+      }
+    };
+    _site.getPage().addPartListener(_partListener);
+  }
+
+  private boolean isOurPart(final IWorkbenchPartReference ref) {
+    if (ref == null || _site == null) return false;
+    final IWorkbenchPart part = ref.getPart(false);
+    return part != null && part == _site.getPart();
+  }
+
+  /**
+   * Force a full redraw of every SWT Control in every shell except the 3D
+   * viewer itself. Cocoa NSView backing stores can become stale after a
+   * JOGL NEWT surface has held the GL context; walking the shell tree and
+   * calling redraw()+update() re-requests the IOSurface for each native
+   * control. Narrowly scoped to #35 — cheap, synchronous, only fires on
+   * part hide / dispose.
+   */
+  private void redrawSiblingPlotCanvases() {
+    final Display display = Display.getDefault();
+    if (display == null || display.isDisposed()) return;
+    display.asyncExec(new Runnable() {
+      @Override public void run() {
+        for (final Shell shell : display.getShells()) {
+          if (!shell.isDisposed()) {
+            redrawRecursive(shell);
+          }
+        }
+      }
+    });
+  }
+
+  private void redrawRecursive(final Control control) {
+    if (control == null || control.isDisposed() || control == VolumeViewer.this) return;
+    control.redraw();
+    control.update();
+    if (control instanceof Composite) {
+      for (final Control child : ((Composite) control).getChildren()) {
+        redrawRecursive(child);
+      }
+    }
   }
 
   @Override
@@ -196,9 +279,23 @@ public class VolumeViewer extends AbstractDataViewer implements IVolumeViewer, I
 
   @Override
   public void dispose() {
+    if (_partListener != null && _site != null && _site.getPage() != null) {
+      _site.getPage().removePartListener(_partListener);
+      _partListener = null;
+    }
+    if (_viewCanvasImpl != null && _viewCanvasImpl.getCanvas() != null) {
+      // Stop the render loop AND destroy the NEWT GLWindow before SWT
+      // disposal tears down the parent composite, so the animator thread
+      // can't call display() on a destroyed GLWindow and the CGLContext
+      // is released promptly (issue #35).
+      _viewCanvasImpl.getCanvas().dispose();
+    }
     super.dispose();
     _store.removePropertyChangeListener(_viewerPropertyListener);
     _openedViewers--;
+    // Force sibling views to repaint — their NSView backing stores may be
+    // stale after the 3D viewer's CGLContext is torn down (issue #35).
+    redrawSiblingPlotCanvases();
   }
 
   @Override

--- a/org.geocraft.ui.volumeviewer/src/org/geocraft/ui/volumeviewer/renderer/seismic/PostStack3dRenderer.java
+++ b/org.geocraft.ui.volumeviewer/src/org/geocraft/ui/volumeviewer/renderer/seismic/PostStack3dRenderer.java
@@ -1,6 +1,8 @@
 package org.geocraft.ui.volumeviewer.renderer.seismic;
 
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 
@@ -117,8 +119,10 @@ public class PostStack3dRenderer extends VolumeViewRenderer {
       k++;
     }
 
-    // Pack vertices into a FloatBuffer
-    final FloatBuffer buf = FloatBuffer.allocate(24 * 3);
+    // Pack vertices into a direct FloatBuffer — JOGL vertex-array draws
+    // require native-memory buffers.
+    final FloatBuffer buf = ByteBuffer.allocateDirect(24 * 3 * Float.BYTES)
+        .order(ByteOrder.nativeOrder()).asFloatBuffer();
     for (int i = 0; i < 24; i++) {
       buf.put(vertex[i].x);
       buf.put(vertex[i].y);
@@ -439,8 +443,11 @@ public class PostStack3dRenderer extends VolumeViewRenderer {
   private MeshGeometry buildSliceGrid(String name, Vector3f[] corners, int cols, int rows,
       float[] data, float dataMin, float dataMax) {
     final int numVerts = cols * rows;
-    final FloatBuffer verts = FloatBuffer.allocate(numVerts * 3);
-    final FloatBuffer colors = FloatBuffer.allocate(numVerts * 4);
+    // Direct buffers — JOGL client-side vertex arrays require native memory.
+    final FloatBuffer verts = ByteBuffer.allocateDirect(numVerts * 3 * Float.BYTES)
+        .order(ByteOrder.nativeOrder()).asFloatBuffer();
+    final FloatBuffer colors = ByteBuffer.allocateDirect(numVerts * 4 * Float.BYTES)
+        .order(ByteOrder.nativeOrder()).asFloatBuffer();
 
     for (int r = 0; r < rows; r++) {
       final float v = rows > 1 ? (float) r / (rows - 1) : 0;
@@ -459,9 +466,10 @@ public class PostStack3dRenderer extends VolumeViewRenderer {
     verts.flip();
     colors.flip();
 
-    // Build triangle indices
+    // Build triangle indices — direct IntBuffer for JOGL glDrawElements.
     final int numTris = (cols - 1) * (rows - 1) * 2;
-    final IntBuffer indices = IntBuffer.allocate(numTris * 3);
+    final IntBuffer indices = ByteBuffer.allocateDirect(numTris * 3 * Integer.BYTES)
+        .order(ByteOrder.nativeOrder()).asIntBuffer();
     for (int r = 0; r < rows - 1; r++) {
       for (int c = 0; c < cols - 1; c++) {
         final int i = r * cols + c;


### PR DESCRIPTION
## Summary

Closes #35.

- `org.geocraft.rendering.jogl` was stuck in `RESOLVED` state because its MANIFEST was missing `Bundle-ActivationPolicy: lazy`, so its DS `RenderBackend` component never registered and the 3D viewer silently rendered black.
- After the service registered, the JOGL render path used immediate-mode `glBegin`/`glEnd` with per-vertex `glVertex3f`/`glColor4f`/`glNormal3f` — unusable on any realistic seismic volume. Rewrote `JoglGeometryUpload` to use client-side vertex arrays, and added transparent heap→direct buffer conversion since JOGL requires native memory.
- `FPSAnimator` started from `ViewCanvasImplementor`'s constructor against a hidden NEWT canvas, and kept running while the 3D view was hidden — under `-XstartOnFirstThread` the render thread held the CGLContext and starved SWT's main-thread paints for sibling views (Section Viewer went black after opening the 3D viewer). Deferred animator start until first `setContentVisible(true)`, paused on part-hide, stopped on dispose. Added sibling-canvas redraw to recover Cocoa NSView IOSurface backing stores after the 3D viewer is hidden or closed.
- Added logging on every formerly-silent failure path (backend lookup, render-pass exceptions, missing backend) so future regressions of this class are not invisible.

Full diagnostic trail is captured in `SWT_MIGRATION_LOG.md` (Symptom 4).

## Test plan

- [x] Launch via Eclipse PDE on macOS 15 / Apple Silicon.
- [x] Generate Test Data → open Section Viewer → renders.
- [x] Open 3D Viewer on the same dataset → renders (not black).
- [x] Switch back to Section Viewer → still renders.
- [x] Close 3D Viewer → Section Viewer still paints on subsequent interaction.
- [x] 3D viewer frame rate usable on test-data PostStack3d volume.
- [ ] Cross-platform verify (Linux / Windows) — not yet run; fix is macOS-focused but changes are platform-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)